### PR TITLE
Update Paperless-ngx backups and autorestic configuration

### DIFF
--- a/ansible/roles/docker-compose-paperless-ngx/files/docker-compose.yml
+++ b/ansible/roles/docker-compose-paperless-ngx/files/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - POSTGRES_USER=paperless
       - POSTGRES_PASSWORD=paperless
       - POSTGRES_EXTRA_OPTS=-Z1 --schema=public --blobs
+      - BACKUP_ON_START=TRUE
       - SCHEDULE=@daily
       - TZ=Europe/Berlin
       - BACKUP_ON_START=TRUE
@@ -78,7 +79,7 @@ services:
     image: pascaliske/autorestic:latest
     restart: always
     environment:
-      - RESTIC_HOST=postgres
+      - RESTIC_HOST=paperless
     volumes:
       - ./autorestic/config.yml:/etc/autorestic/config.yml
       - ./autorestic/cron:/etc/cron/

--- a/ansible/roles/docker-compose-paperless-ngx/templates/config.yml.j2
+++ b/ansible/roles/docker-compose-paperless-ngx/templates/config.yml.j2
@@ -6,7 +6,7 @@ backends:
     key: {{ lookup('community.general.passwordstore', 'accounts/borgbase.com/repos/docker' ) }}
     # requireKey: true
 locations:
-  postgres-backups:
+  paperless-backups:
     cron: '17 3 * * *'
     from: /backups
     to:


### PR DESCRIPTION
- Add `BACKUP_ON_START` environment variable to Docker Compose for Paperless-ngx backups.
- Modify `RESTIC_HOST` and backup location names for clarity and consistency.