### PR TITLE
Update Paperless-ngx backups and autorestic configuration

### DIFF
--- a/ansible/roles/docker-compose-paperless-ngx/files/docker-compose.yml
+++ b/ansible/roles/docker-compose-paperless-ngx/files/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       POSTGRES_USER: paperless
       POSTGRES_PASSWORD: paperless
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: [ "CMD-SHELL", "pg_isready -U paperless -d paperless" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
- Add `BACKUP_ON_START` environment variable to Docker Compose for Paperless-ngx backups.
- Modify `RESTIC_HOST` and backup location names for clarity and consistency.