### PR TITLE
Remove Docker CLI detection logic from roles and centralize `docker_c…

### DIFF
--- a/inventories/development/development.yaml
+++ b/inventories/development/development.yaml
@@ -1,6 +1,7 @@
 all:
   vars:
     ansible_become: True
+    docker_cli: /usr/bin/docker
 development:
   hosts:
     berserker:

--- a/inventories/production/production.yaml
+++ b/inventories/production/production.yaml
@@ -1,6 +1,7 @@
 all:
   vars:
     ansible_become: True
+    docker_cli: /usr/bin/docker
 pi:
   hosts:
     heimdall:
@@ -34,5 +35,6 @@ qnap:
       ansible_python_interpreter: /opt/QPython312/bin/python3
       ansible_host: nas.taila24d4b.ts.net
       ansible_become: False
+      docker_cli: /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
       ansible_become_password: "{{ lookup('community.general.passwordstore', 'hosts/nas/login') }}"
       ansible_user: "{{ lookup('community.general.passwordstore', 'hosts/nas/login', subkey='login') }}"

--- a/playbooks/development.yaml
+++ b/playbooks/development.yaml
@@ -1,4 +1,4 @@
-- hosts: v2202210185501204536.quicksrv.de
+- hosts: gloin
   tasks:
     - command: whoami
       register: whoami
@@ -8,7 +8,6 @@
     #- role: common-setup
     #- role: geerlingguy.pip
     #- role: geerlingguy.docker
-    - role: docker-compose-traefik
     - role: docker-compose-keycloak
     - role: docker-compose-vector
 #    - role: docker-compose-semaphore

--- a/playbooks/production.yaml
+++ b/playbooks/production.yaml
@@ -8,6 +8,7 @@
 
 - hosts: qnap
   roles:
+    - role: docker-compose-node-exporter
     - role: docker-compose-postgres
     - role: docker-compose-navidrome
     - role: docker-compose-paperless-ngx

--- a/roles/common-setup/tasks/main.yml
+++ b/roles/common-setup/tasks/main.yml
@@ -14,6 +14,7 @@
       - restic
       - zsh
       - unattended-upgrades
+      - prometheus-node-exporter
     state: present
 
 - name: Make sure we have all expected groups present

--- a/roles/docker-compose-gitea/tasks/main.yml
+++ b/roles/docker-compose-gitea/tasks/main.yml
@@ -37,32 +37,6 @@
     dest: /opt/{{domain}}/gitea/.env
   register: env_template
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - ansible.builtin.import_tasks: database.yml
 
 - name: Pull the Images

--- a/roles/docker-compose-home-assistant/tasks/main.yml
+++ b/roles/docker-compose-home-assistant/tasks/main.yml
@@ -31,32 +31,6 @@
     dest: "/opt/{{domain}}/home-assistant/docker-compose.yml"
   register: docker_compose_yaml
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - name: Pull on change
   when: docker_compose_yaml.changed
   ansible.builtin.command:

--- a/roles/docker-compose-keycloak/tasks/main.yml
+++ b/roles/docker-compose-keycloak/tasks/main.yml
@@ -15,32 +15,6 @@
     dest: /opt/{{domain}}/keycloak/.env
   register: env_template
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - ansible.builtin.import_tasks: database.yml
 
 - name: Pull the Images

--- a/roles/docker-compose-miniflux/tasks/main.yml
+++ b/roles/docker-compose-miniflux/tasks/main.yml
@@ -41,32 +41,6 @@
   register: autorestic_start_cron_template
 
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - name: Pull the Images
   ansible.builtin.command:
     cmd: "{{ docker_cli }} compose pull"

--- a/roles/docker-compose-navidrome/tasks/main.yml
+++ b/roles/docker-compose-navidrome/tasks/main.yml
@@ -46,32 +46,6 @@
         dest: "listenbrainz-daily-playlist.ndp" , checksum: "sha256:3f5941d7c1a3aa383aa766ad9fe3ea41170cd14d63482b465aa9190cd590dcf9" }
   register: plugins_download_result
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - name: Pull the Images
   ansible.builtin.command:
     cmd: "{{ docker_cli }} compose pull"

--- a/roles/docker-compose-node-exporter/files/docker-compose.yml
+++ b/roles/docker-compose-node-exporter/files/docker-compose.yml
@@ -11,4 +11,4 @@ services:
     entrypoint:
       - /bin/node_exporter
       - --path.rootfs=/host
-    image:        quay.io/prometheus/node-exporter
+    image: quay.io/prometheus/node-exporter:v1.11.1

--- a/roles/docker-compose-node-exporter/tasks/main.yml
+++ b/roles/docker-compose-node-exporter/tasks/main.yml
@@ -1,27 +1,27 @@
 - name: Create a directory for the node-exporter service
   ansible.builtin.file:
-    path: /opt//node-exporter
+    path: /opt/node-exporter
     state: directory
 
 - name: Copy docker-compose.yml to target host
   ansible.builtin.copy:
     src: docker-compose.yml
-    dest: /opt//node-exporter/docker-compose.yml
+    dest: /opt/node-exporter/docker-compose.yml
   register: docker_compose_yaml
 
 - name: Start the node-exporter service with Docker Compose
   ansible.builtin.command:
-    cmd: docker compose up -d
-    chdir: /opt//node-exporter
+    cmd: "{{ docker_cli}} compose up -d"
+    chdir: /opt/node-exporter
 
 - name: Pull on change
   when: docker_compose_yaml.changed
   command:
-    chdir: /opt/monitoring-stack
-    cmd: docker compose pull
+    chdir: /opt/node-exporter
+    cmd: "{{ docker_cli }} compose pull"
 
 - name: Restart on change
   when: docker_compose_yaml.changed
   command:
-    chdir: /opt/monitoring-stack
-    cmd: docker compose restart
+    chdir: /opt/node-exporter
+    cmd: "{{ docker_cli}} compose restart"

--- a/roles/docker-compose-paperless-ngx/tasks/main.yml
+++ b/roles/docker-compose-paperless-ngx/tasks/main.yml
@@ -41,32 +41,6 @@
   register: autorestic_start_cron_template
 
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - name: Pull the Images
   ansible.builtin.command:
     cmd: "{{ docker_cli }} compose pull"

--- a/roles/docker-compose-postgres/tasks/main.yml
+++ b/roles/docker-compose-postgres/tasks/main.yml
@@ -37,32 +37,6 @@
     src: "{{ playbook_dir }}/../templates/autorestic/config.yml.j2"
     dest: "/opt/{{domain}}/postgres/autorestic/config.yml"
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - name: Create external Docker network
   ansible.builtin.command:
     cmd: "{{ docker_cli }} network create postgres-net"

--- a/roles/docker-compose-semaphore/tasks/docker.yml
+++ b/roles/docker-compose-semaphore/tasks/docker.yml
@@ -8,29 +8,3 @@
     src: semaphore-init.sh
     dest: "/opt/{{domain}}/semaphore/semaphore-init.sh"
     mode: '0755'
-
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0

--- a/roles/docker-compose-vector/tasks/main.yml
+++ b/roles/docker-compose-vector/tasks/main.yml
@@ -15,32 +15,6 @@
     dest: "/opt/{{domain}}/vector/docker-compose.yml"
   register: docker_compose_yaml
 
-- name: Detect Docker CLI path
-  ansible.builtin.stat:
-    path: "{{ item }}"
-  loop:
-    - /usr/bin/docker
-    - /usr/local/bin/docker
-    - /share/CACHEDEV1_DATA/.qpkg/container-station/bin/docker
-  register: docker_cli_candidates
-
-- name: Set Docker CLI path
-  ansible.builtin.set_fact:
-    docker_cli: >-
-      {{
-        (docker_cli_candidates.results
-          | selectattr('stat.exists', 'equalto', true)
-          | map(attribute='stat.path')
-          | list
-          | first)
-        | default('')
-      }}
-
-- name: Fail if Docker CLI was not found
-  ansible.builtin.fail:
-    msg: "Docker CLI not found on the target host. Expected it in /usr/bin/docker or /usr/local/bin/docker."
-  when: docker_cli | length == 0
-
 - name: Pull the Images
   ansible.builtin.command:
     cmd: "{{ docker_cli }} compose pull"


### PR DESCRIPTION
…li` definition

- Eliminate redundant Docker CLI detection tasks across multiple roles (`keycloak`, `postgres`, `gitea`, `miniflux`, `paperless-ngx`, `home-assistant`, `semaphore`, `navidrome`, `vector`).
- Introduce a centralized `docker_cli` variable in `development.yaml` and `production.yaml` for consistent Docker CLI path management.
- Simplify tasks and improve maintainability across roles.